### PR TITLE
fix model accessors for runtime

### DIFF
--- a/src/main/java/com/classroomscheduler/model/Espaco.java
+++ b/src/main/java/com/classroomscheduler/model/Espaco.java
@@ -9,13 +9,7 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 public abstract class Espaco {
@@ -35,4 +29,55 @@ public abstract class Espaco {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "predio_id")
     private Predio predio;
+
+    public Espaco() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public Integer getCapacidade() {
+        return capacidade;
+    }
+
+    public void setCapacidade(Integer capacidade) {
+        this.capacidade = capacidade;
+    }
+
+    public boolean isIndisponivel() {
+        return indisponivel;
+    }
+
+    public void setIndisponivel(boolean indisponivel) {
+        this.indisponivel = indisponivel;
+    }
+
+    public String getMotivoIndisponibilidade() {
+        return motivoIndisponibilidade;
+    }
+
+    public void setMotivoIndisponibilidade(String motivoIndisponibilidade) {
+        this.motivoIndisponibilidade = motivoIndisponibilidade;
+    }
+
+    public Predio getPredio() {
+        return predio;
+    }
+
+    public void setPredio(Predio predio) {
+        this.predio = predio;
+    }
 }

--- a/src/main/java/com/classroomscheduler/model/Horarios.java
+++ b/src/main/java/com/classroomscheduler/model/Horarios.java
@@ -2,15 +2,9 @@ package com.classroomscheduler.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
-@NoArgsConstructor
 @Embeddable
 public class Horarios {
 
@@ -19,6 +13,9 @@ public class Horarios {
 
     @Column(name = "fim", nullable = false)
     private LocalDateTime fim;
+
+    public Horarios() {
+    }
 
     public boolean conflita(Horarios outro) {
         if (outro == null || inicio == null || fim == null || outro.inicio == null || outro.fim == null) {
@@ -36,5 +33,21 @@ public class Horarios {
         if (!fim.isAfter(inicio)) {
             throw new IllegalStateException("Fim deve ser posterior ao inicio.");
         }
+    }
+
+    public LocalDateTime getInicio() {
+        return inicio;
+    }
+
+    public void setInicio(LocalDateTime inicio) {
+        this.inicio = inicio;
+    }
+
+    public LocalDateTime getFim() {
+        return fim;
+    }
+
+    public void setFim(LocalDateTime fim) {
+        this.fim = fim;
     }
 }

--- a/src/main/java/com/classroomscheduler/model/Notificacao.java
+++ b/src/main/java/com/classroomscheduler/model/Notificacao.java
@@ -8,15 +8,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
-@NoArgsConstructor
 @Entity
 public class Notificacao {
 
@@ -38,10 +32,61 @@ public class Notificacao {
 
     private LocalDateTime enviadaEm;
 
+    public Notificacao() {
+    }
+
     @PrePersist
     void prePersist() {
         if (enviadaEm == null) {
             enviadaEm = LocalDateTime.now();
         }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Usuario getDestinatario() {
+        return destinatario;
+    }
+
+    public void setDestinatario(Usuario destinatario) {
+        this.destinatario = destinatario;
+    }
+
+    public Reserva getReserva() {
+        return reserva;
+    }
+
+    public void setReserva(Reserva reserva) {
+        this.reserva = reserva;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public void setMensagem(String mensagem) {
+        this.mensagem = mensagem;
+    }
+
+    public boolean isLida() {
+        return lida;
+    }
+
+    public void setLida(boolean lida) {
+        this.lida = lida;
+    }
+
+    public LocalDateTime getEnviadaEm() {
+        return enviadaEm;
+    }
+
+    public void setEnviadaEm(LocalDateTime enviadaEm) {
+        this.enviadaEm = enviadaEm;
     }
 }

--- a/src/main/java/com/classroomscheduler/model/Predio.java
+++ b/src/main/java/com/classroomscheduler/model/Predio.java
@@ -4,13 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
 @Entity
 public class Predio {
 
@@ -23,4 +17,39 @@ public class Predio {
     private String codigo;
 
     private String localizacao;
+
+    public Predio() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public String getLocalizacao() {
+        return localizacao;
+    }
+
+    public void setLocalizacao(String localizacao) {
+        this.localizacao = localizacao;
+    }
 }

--- a/src/main/java/com/classroomscheduler/model/Reserva.java
+++ b/src/main/java/com/classroomscheduler/model/Reserva.java
@@ -10,15 +10,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
-@NoArgsConstructor
 @Entity
 public class Reserva {
 
@@ -43,6 +37,9 @@ public class Reserva {
 
     private LocalDateTime criadaEm;
 
+    public Reserva() {
+    }
+
     @PrePersist
     void prePersist() {
         validarReserva();
@@ -62,5 +59,61 @@ public class Reserva {
         }
 
         horarios.validar();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Solicitante getSolicitante() {
+        return solicitante;
+    }
+
+    public void setSolicitante(Solicitante solicitante) {
+        this.solicitante = solicitante;
+    }
+
+    public Espaco getEspaco() {
+        return espaco;
+    }
+
+    public void setEspaco(Espaco espaco) {
+        this.espaco = espaco;
+    }
+
+    public Horarios getHorarios() {
+        return horarios;
+    }
+
+    public void setHorarios(Horarios horarios) {
+        this.horarios = horarios;
+    }
+
+    public String getMotivo() {
+        return motivo;
+    }
+
+    public void setMotivo(String motivo) {
+        this.motivo = motivo;
+    }
+
+    public boolean isCancelada() {
+        return cancelada;
+    }
+
+    public void setCancelada(boolean cancelada) {
+        this.cancelada = cancelada;
+    }
+
+    public LocalDateTime getCriadaEm() {
+        return criadaEm;
+    }
+
+    public void setCriadaEm(LocalDateTime criadaEm) {
+        this.criadaEm = criadaEm;
     }
 }

--- a/src/main/java/com/classroomscheduler/model/Usuario.java
+++ b/src/main/java/com/classroomscheduler/model/Usuario.java
@@ -6,13 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 public abstract class Usuario {
@@ -24,4 +18,31 @@ public abstract class Usuario {
     private String nome;
 
     private String email;
+
+    public Usuario() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
 }


### PR DESCRIPTION
## What changed
Added explicit constructors, getters, and setters to the core domain models used by the current runtime flow.

## Why it changed
The application was failing to compile and start because the current build was not resolving the expected Lombok-generated accessors in the model layer.

## Impact
This removes the runtime-critical dependency on generated accessors for the affected models and allows services and controllers to interact with the domain objects consistently.

## Validation
- Started the application with JDK 25 in the shell session
- Confirmed `GET /health` returned `{\"status\":\"ok\"}` before stopping the process
