### PR TITLE
fix notificacao request flow

### DIFF
--- a/docs/api-collection.postman_collection.json
+++ b/docs/api-collection.postman_collection.json
@@ -98,7 +98,7 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{baseUrl}}/usuarios/buscar?email=admin@insper.edu.br",
+              "raw": "{{baseUrl}}/usuarios/buscar?email=admin@classroom.local",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -109,7 +109,7 @@
               "query": [
                 {
                   "key": "email",
-                  "value": "admin@insper.edu.br"
+                  "value": "admin@classroom.local"
                 }
               ]
             }
@@ -631,7 +631,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"destinatario\": {\n    \"id\": {{destinatarioId}}\n  },\n  \"reserva\": {\n    \"id\": {{reservaId}}\n  },\n  \"mensagem\": \"Sua reserva foi confirmada\"\n}"
+              "raw": "{\n  \"destinatarioId\": {{destinatarioId}},\n  \"reservaId\": {{reservaId}},\n  \"mensagem\": \"Sua reserva foi confirmada\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/notificacoes",

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -184,12 +184,8 @@ Exemplo de body:
 
 ```json
 {
-  "destinatario": {
-    "id": 2
-  },
-  "reserva": {
-    "id": 10
-  },
+  "destinatarioId": 2,
+  "reservaId": 10,
   "mensagem": "Sua reserva foi confirmada"
 }
 ```

--- a/src/main/java/com/classroomscheduler/controller/NotificacaoController.java
+++ b/src/main/java/com/classroomscheduler/controller/NotificacaoController.java
@@ -1,5 +1,6 @@
 package com.classroomscheduler.controller;
 
+import com.classroomscheduler.dto.CreateNotificacaoRequest;
 import com.classroomscheduler.model.Notificacao;
 import com.classroomscheduler.service.NotificacaoService;
 import org.springframework.http.HttpStatus;
@@ -46,8 +47,8 @@ public class NotificacaoController {
     }
 
     @PostMapping
-    public ResponseEntity<Notificacao> criar(@RequestBody Notificacao notificacao) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(notificacaoService.salvar(notificacao));
+    public ResponseEntity<Notificacao> criar(@RequestBody CreateNotificacaoRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(notificacaoService.salvar(request));
     }
 
     @PatchMapping("/{id}/lida")

--- a/src/main/java/com/classroomscheduler/dto/CreateNotificacaoRequest.java
+++ b/src/main/java/com/classroomscheduler/dto/CreateNotificacaoRequest.java
@@ -1,0 +1,37 @@
+package com.classroomscheduler.dto;
+
+public class CreateNotificacaoRequest {
+
+    private Long destinatarioId;
+
+    private Long reservaId;
+
+    private String mensagem;
+
+    public CreateNotificacaoRequest() {
+    }
+
+    public Long getDestinatarioId() {
+        return destinatarioId;
+    }
+
+    public void setDestinatarioId(Long destinatarioId) {
+        this.destinatarioId = destinatarioId;
+    }
+
+    public Long getReservaId() {
+        return reservaId;
+    }
+
+    public void setReservaId(Long reservaId) {
+        this.reservaId = reservaId;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public void setMensagem(String mensagem) {
+        this.mensagem = mensagem;
+    }
+}

--- a/src/main/java/com/classroomscheduler/service/NotificacaoService.java
+++ b/src/main/java/com/classroomscheduler/service/NotificacaoService.java
@@ -1,7 +1,12 @@
 package com.classroomscheduler.service;
 
+import com.classroomscheduler.dto.CreateNotificacaoRequest;
 import com.classroomscheduler.model.Notificacao;
+import com.classroomscheduler.model.Reserva;
+import com.classroomscheduler.model.Usuario;
 import com.classroomscheduler.repository.NotificacaoRepository;
+import com.classroomscheduler.repository.ReservaRepository;
+import com.classroomscheduler.repository.UsuarioRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,9 +16,17 @@ import java.util.NoSuchElementException;
 public class NotificacaoService {
 
     private final NotificacaoRepository notificacaoRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final ReservaRepository reservaRepository;
 
-    public NotificacaoService(NotificacaoRepository notificacaoRepository) {
+    public NotificacaoService(
+            NotificacaoRepository notificacaoRepository,
+            UsuarioRepository usuarioRepository,
+            ReservaRepository reservaRepository
+    ) {
         this.notificacaoRepository = notificacaoRepository;
+        this.usuarioRepository = usuarioRepository;
+        this.reservaRepository = reservaRepository;
     }
 
     public List<Notificacao> listarTodas() {
@@ -33,7 +46,29 @@ public class NotificacaoService {
                 .orElseThrow(() -> new NoSuchElementException("Notificacao nao encontrada."));
     }
 
-    public Notificacao salvar(Notificacao notificacao) {
+    public Notificacao salvar(CreateNotificacaoRequest request) {
+        if (request.getDestinatarioId() == null) {
+            throw new IllegalArgumentException("Notificacao deve possuir destinatario.");
+        }
+
+        if (request.getMensagem() == null || request.getMensagem().isBlank()) {
+            throw new IllegalArgumentException("Notificacao deve possuir mensagem.");
+        }
+
+        Usuario destinatario = usuarioRepository.findById(request.getDestinatarioId())
+                .orElseThrow(() -> new NoSuchElementException("Usuario destinatario nao encontrado."));
+
+        Notificacao notificacao = new Notificacao();
+        notificacao.setDestinatario(destinatario);
+        notificacao.setMensagem(request.getMensagem());
+        notificacao.setLida(false);
+
+        if (request.getReservaId() != null) {
+            Reserva reserva = reservaRepository.findById(request.getReservaId())
+                    .orElseThrow(() -> new NoSuchElementException("Reserva nao encontrada."));
+            notificacao.setReserva(reserva);
+        }
+
         return notificacaoRepository.save(notificacao);
     }
 


### PR DESCRIPTION
## What changed
Fixed the notification creation flow so the API no longer expects a nested `Usuario` entity in the request body.

## Why it changed
`POST /notificacoes` was failing because `destinatario` is mapped as the abstract type `Usuario`, which breaks request deserialization when sending JSON directly as an entity.

## Impact
- Adds a request DTO for notification creation
- Resolves `destinatarioId` and optional `reservaId` in the service layer
- Keeps the API contract simple and testable by Postman
- Updates the API docs to reflect the correct request shape

## Validation
- `./mvnw -q -DskipTests compile` with JDK 25
