### PR TITLE
add local demo data seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,24 +176,33 @@ src/main/java/com/classroomscheduler
 `-- ApiApplication.java
 ```
 
-## Endpoints planejados
+## Endpoints atuais
 
 ### Espacos
 
 - `GET /espacos`
 - `GET /espacos/disponiveis`
-- `POST /espacos` (admin)
+- `GET /espacos/por-predio?predioId=...`
+- `POST /espacos`
+- `PATCH /espacos/{id}/indisponibilidade`
 
 ### Reservas
 
 - `POST /reservas`
-- `GET /reservas/minhas`
-- `PUT /reservas/{id}/cancelar`
+- `GET /reservas`
+- `GET /reservas/{id}`
+- `GET /reservas/ativas`
+- `GET /reservas/por-solicitante?solicitanteId=...`
+- `PATCH /reservas/{id}/cancelar`
 
-### Notificacoes e apoio administrativo
+### Solicitantes, usuarios e notificacoes
 
+- `GET /solicitantes`
+- `POST /solicitantes`
+- `GET /usuarios`
 - `GET /notificacoes`
-- `PATCH /espacos/{id}/indisponibilidade`
+- `POST /notificacoes`
+- `PATCH /notificacoes/{id}/lida`
 
 Os detalhes de contratos e exemplos estao em [docs/endpoints.md](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/endpoints.md).
 
@@ -208,6 +217,22 @@ Pre-requisitos:
 Executar a aplicacao:
 
 ```powershell
+.\mvnw spring-boot:run
+```
+
+Por padrao, a aplicacao sobe com uma seed local de demonstracao habilitada. Ela cria:
+
+- um `Admin` padrao
+- dois `Predios`
+- quatro `Espacos`
+- dois `Solicitantes`
+- uma `Reserva` futura de exemplo
+- `Notificacoes` iniciais para explorar a API
+
+Para desligar a seed local, defina:
+
+```powershell
+$env:APP_DEMO_DATA_ENABLED='false'
 .\mvnw spring-boot:run
 ```
 
@@ -251,6 +276,7 @@ Como o banco esta em memoria, os dados sao perdidos ao encerrar a aplicacao.
 - [Modelagem de dominio](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/modelagem-de-dominio.md)
 - [Regras de negocio](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/regras-de-negocio.md)
 - [Endpoints da API](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/endpoints.md)
+- [Contrato OpenAPI](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/openapi.json)
 - [Collection Postman](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/api-collection.postman_collection.json)
 - [Backlog do produto](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/backlog-do-produto.md)
 - [Padrao de commits e PRs](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/padrao-de-commits-e-prs.md)

--- a/docs/api-collection.postman_collection.json
+++ b/docs/api-collection.postman_collection.json
@@ -23,7 +23,7 @@
     },
     {
       "key": "solicitanteId",
-      "value": "1"
+      "value": "2"
     },
     {
       "key": "reservaId",
@@ -31,7 +31,7 @@
     },
     {
       "key": "destinatarioId",
-      "value": "1"
+      "value": "2"
     },
     {
       "key": "notificacaoId",
@@ -98,7 +98,7 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{baseUrl}}/usuarios/buscar?email=admin@insper.edu.br",
+              "raw": "{{baseUrl}}/usuarios/buscar?email=admin@classroom.local",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -109,7 +109,7 @@
               "query": [
                 {
                   "key": "email",
-                  "value": "admin@insper.edu.br"
+                  "value": "admin@classroom.local"
                 }
               ]
             }
@@ -172,7 +172,7 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{baseUrl}}/solicitantes/buscar?email=aluno@insper.edu.br",
+              "raw": "{{baseUrl}}/solicitantes/buscar?email=ana.souza@classroom.local",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -183,7 +183,7 @@
               "query": [
                 {
                   "key": "email",
-                  "value": "aluno@insper.edu.br"
+                  "value": "ana.souza@classroom.local"
                 }
               ]
             }
@@ -255,7 +255,7 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{baseUrl}}/predios/buscar?codigo=A",
+              "raw": "{{baseUrl}}/predios/buscar?codigo=BL-A",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -266,7 +266,7 @@
               "query": [
                 {
                   "key": "codigo",
-                  "value": "A"
+                  "value": "BL-A"
                 }
               ]
             }
@@ -284,7 +284,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"nome\": \"Predio A\",\n  \"codigo\": \"A\",\n  \"localizacao\": \"Campus principal\"\n}"
+              "raw": "{\n  \"nome\": \"Predio C\",\n  \"codigo\": \"C\",\n  \"localizacao\": \"Bloco complementar\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/predios",
@@ -509,7 +509,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"solicitanteId\": {{solicitanteId}},\n  \"espacoId\": {{espacoId}},\n  \"inicio\": \"2026-05-10T10:00:00\",\n  \"fim\": \"2026-05-10T12:00:00\",\n  \"motivo\": \"Apresentacao de projeto\"\n}"
+              "raw": "{\n  \"solicitanteId\": {{solicitanteId}},\n  \"espacoId\": {{espacoId}},\n  \"inicio\": \"2030-05-10T10:00:00\",\n  \"fim\": \"2030-05-10T12:00:00\",\n  \"motivo\": \"Apresentacao de projeto\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/reservas",

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -2,59 +2,129 @@
 
 ## Visao geral
 
-Os endpoints abaixo representam a API planejada para o `Classroom Scheduler`, organizada em torno das classes obrigatorias do dominio.
-
 Base local:
 
 ```text
 http://localhost:8080
 ```
 
-## Espacos
+Contrato OpenAPI exportado:
 
-### `GET /espacos`
+- [OpenAPI JSON](/C:/Users/Usuario/Documents/Insper/arq_obj/Agendamento/docs/openapi.json)
 
-Lista todos os espacos cadastrados.
+## Health
 
-Uso principal:
+### `GET /health`
 
-- consulta geral de espacos
-- apoio para tela de listagem
+Retorna o status basico da aplicacao.
 
-### `GET /espacos/disponiveis`
+## Usuarios
 
-Lista espacos disponiveis para um intervalo e filtros informados.
+### `GET /usuarios`
 
-Parametros sugeridos:
+Lista todos os usuarios.
 
-- `inicio`
-- `fim`
-- `capacidadeMinima`
-- `tipo`
-- `predioId`
+### `GET /usuarios/{id}`
 
-Exemplo:
+Busca um usuario por id.
 
-```text
-GET /espacos/disponiveis?inicio=2026-05-10T10:00:00&fim=2026-05-10T12:00:00&capacidadeMinima=30&tipo=AUDITORIO
-```
+### `GET /usuarios/buscar?email=...`
 
-### `POST /espacos`
+Busca um usuario por email.
 
-Cria um novo espaco concreto. Endpoint administrativo e util para montar o fluxo completo de testes.
+### `DELETE /usuarios/{id}`
+
+Remove um usuario por id.
+
+## Solicitantes
+
+### `GET /solicitantes`
+
+Lista todos os solicitantes.
+
+### `GET /solicitantes/{id}`
+
+Busca um solicitante por id.
+
+### `GET /solicitantes/buscar?email=...`
+
+Busca um solicitante por email.
+
+### `POST /solicitantes`
+
+Cria um solicitante.
 
 Exemplo de body:
 
 ```json
 {
-  "nome": "Laboratorio C204",
-  "tipo": "LABORATORIO",
+  "nome": "Maria Souza",
+  "email": "maria@insper.edu.br"
+}
+```
+
+## Predios
+
+### `GET /predios`
+
+Lista todos os predios.
+
+### `GET /predios/{id}`
+
+Busca um predio por id.
+
+### `GET /predios/buscar?codigo=...`
+
+Busca um predio por codigo.
+
+### `POST /predios`
+
+Cria um predio.
+
+Exemplo de body:
+
+```json
+{
+  "nome": "Predio A",
+  "codigo": "A",
+  "localizacao": "Campus principal"
+}
+```
+
+## Espacos
+
+### `GET /espacos`
+
+Lista todos os espacos.
+
+### `GET /espacos/{id}`
+
+Busca um espaco por id.
+
+### `GET /espacos/disponiveis`
+
+Lista espacos com `indisponivel = false`.
+
+### `GET /espacos/por-predio?predioId=...`
+
+Lista os espacos vinculados a um predio.
+
+### `POST /espacos`
+
+Cria um espaco concreto.
+
+Exemplo de body:
+
+```json
+{
+  "nome": "Sala B201",
+  "tipo": "SALA",
   "capacidade": 40,
   "predioId": 1
 }
 ```
 
-Tipos aceitos em `tipo`:
+Tipos aceitos:
 
 - `SALA`
 - `AUDITORIO`
@@ -63,7 +133,7 @@ Tipos aceitos em `tipo`:
 
 ### `PATCH /espacos/{id}/indisponibilidade`
 
-Marca ou remove indisponibilidade de um espaco. Endpoint administrativo.
+Marca ou remove indisponibilidade de um espaco.
 
 Exemplo de body:
 
@@ -76,99 +146,41 @@ Exemplo de body:
 
 ## Reservas
 
+### `GET /reservas`
+
+Lista todas as reservas.
+
+### `GET /reservas/{id}`
+
+Busca uma reserva por id.
+
+### `GET /reservas/ativas`
+
+Lista reservas nao canceladas.
+
+### `GET /reservas/por-solicitante?solicitanteId=...`
+
+Lista reservas de um solicitante.
+
 ### `POST /reservas`
 
-Cria uma reserva para um `Solicitante` em um `Espaco` usando um body simples com IDs e intervalo.
+Cria uma reserva.
 
 Exemplo de body:
 
 ```json
 {
   "solicitanteId": 2,
-  "espacoId": 5,
-  "inicio": "2026-05-10T10:00:00",
-  "fim": "2026-05-10T12:00:00",
+  "espacoId": 1,
+  "inicio": "2030-05-10T10:00:00",
+  "fim": "2030-05-10T12:00:00",
   "motivo": "Apresentacao de projeto"
 }
-```
-
-### `GET /reservas`
-
-Lista todas as reservas cadastradas.
-
-### `GET /reservas/ativas`
-
-Lista apenas as reservas nao canceladas.
-
-### `GET /reservas/por-solicitante`
-
-Lista as reservas de um solicitante pelo `solicitanteId`.
-
-Exemplo:
-
-```text
-GET /reservas/por-solicitante?solicitanteId=2
 ```
 
 ### `PATCH /reservas/{id}/cancelar`
 
 Cancela uma reserva.
-
-Regras:
-
-- `Solicitante` cancela apenas a propria reserva
-- `Admin` pode cancelar qualquer reserva
-
-Exemplo de path:
-
-```text
-PUT /reservas/10/cancelar
-```
-
-## Solicitantes
-
-### `GET /solicitantes`
-
-Lista os solicitantes cadastrados.
-
-### `GET /solicitantes/{id}`
-
-Busca um solicitante por identificador.
-
-### `GET /solicitantes/buscar`
-
-Busca um solicitante por email.
-
-Exemplo:
-
-```text
-GET /solicitantes/buscar?email=aluno@insper.edu.br
-```
-
-### `POST /solicitantes`
-
-Cria um solicitante para uso no fluxo de reserva.
-
-Exemplo de body:
-
-```json
-{
-  "nome": "Maria Souza",
-  "email": "maria@insper.edu.br"
-}
-```
-
-## Admin padrao
-
-O `Admin` nao possui endpoint de criacao publica neste ajuste. A aplicacao cria um administrador padrao ao subir, usando variaveis de ambiente:
-
-- `APP_ADMIN_NOME`
-- `APP_ADMIN_EMAIL`
-
-Valores default quando nao configurados:
-
-- nome: `Administrador Padrao`
-- email: `admin@classroom.local`
 
 ## Notificacoes
 
@@ -176,9 +188,21 @@ Valores default quando nao configurados:
 
 Lista todas as notificacoes.
 
+### `GET /notificacoes/{id}`
+
+Busca uma notificacao por id.
+
+### `GET /notificacoes/por-destinatario?destinatarioId=...`
+
+Lista notificacoes de um destinatario.
+
+### `GET /notificacoes/nao-lidas?destinatarioId=...`
+
+Lista notificacoes nao lidas de um destinatario.
+
 ### `POST /notificacoes`
 
-Cria uma notificacao. Em geral este endpoint pode ser interno ou administrativo, dependendo da arquitetura adotada.
+Cria uma notificacao usando referencias por objeto.
 
 Exemplo de body:
 
@@ -188,7 +212,7 @@ Exemplo de body:
     "id": 2
   },
   "reserva": {
-    "id": 10
+    "id": 1
   },
   "mensagem": "Sua reserva foi confirmada"
 }
@@ -198,14 +222,20 @@ Exemplo de body:
 
 Marca uma notificacao como lida.
 
-## Perfis de acesso
+## Seed local
 
-- `Solicitante`: criado via API para testar reservas, consultar espacos, criar reserva, listar reservas e consultar notificacoes
-- `Admin`: bootstrapado por ambiente, sem criacao publica via API, e reservado para acoes administrativas
+Com a seed local habilitada, a aplicacao sobe com dados basicos para demonstracao:
+
+- `usuarioId = 1` para o admin padrao
+- `predioId = 1` e `predioId = 2`
+- `espacoId = 1` para `Sala 101`
+- `solicitanteId = 2` para `Ana Souza`
+- `destinatarioId = 2` para notificacoes da Ana
+- `reservaId = 1` para a reserva de exemplo
 
 ## Respostas esperadas
 
-- `200 OK`: consulta ou atualizacao realizada com sucesso
-- `201 Created`: recurso criado com sucesso
-- `400 Bad Request`: violacao de regra de negocio ou dados invalidos
-- `404 Not Found`: espaco, usuario, reserva, predio ou notificacao inexistente
+- `200 OK` para consultas e atualizacoes
+- `201 Created` para criacao de recursos
+- `400 Bad Request` para dados invalidos ou violacao de regra
+- `404 Not Found` para recurso inexistente

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1097 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/solicitantes": {
+      "get": {
+        "tags": [
+          "solicitante-controller"
+        ],
+        "operationId": "listarTodos",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Solicitante"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "solicitante-controller"
+        ],
+        "operationId": "criar",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSolicitanteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Solicitante"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reservas": {
+      "get": {
+        "tags": [
+          "reserva-controller"
+        ],
+        "operationId": "listarTodas",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Reserva"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "reserva-controller"
+        ],
+        "operationId": "criar_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateReservaRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reserva"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predios": {
+      "get": {
+        "tags": [
+          "predio-controller"
+        ],
+        "operationId": "listarTodos_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Predio"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "predio-controller"
+        ],
+        "operationId": "criar_2",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Predio"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Predio"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notificacoes": {
+      "get": {
+        "tags": [
+          "notificacao-controller"
+        ],
+        "operationId": "listarTodas_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Notificacao"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "notificacao-controller"
+        ],
+        "operationId": "criar_3",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Notificacao"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Notificacao"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/espacos": {
+      "get": {
+        "tags": [
+          "espaco-controller"
+        ],
+        "operationId": "listarTodos_2",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Espaco"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "espaco-controller"
+        ],
+        "operationId": "criar_4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEspacoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Espaco"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reservas/{id}/cancelar": {
+      "patch": {
+        "tags": [
+          "reserva-controller"
+        ],
+        "operationId": "cancelar",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reserva"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notificacoes/{id}/lida": {
+      "patch": {
+        "tags": [
+          "notificacao-controller"
+        ],
+        "operationId": "marcarComoLida",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Notificacao"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/espacos/{id}/indisponibilidade": {
+      "patch": {
+        "tags": [
+          "espaco-controller"
+        ],
+        "operationId": "atualizarIndisponibilidade",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Espaco"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/usuarios": {
+      "get": {
+        "tags": [
+          "usuario-controller"
+        ],
+        "operationId": "listarTodos_3",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Usuario"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/usuarios/{id}": {
+      "get": {
+        "tags": [
+          "usuario-controller"
+        ],
+        "operationId": "buscarPorId",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Usuario"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "usuario-controller"
+        ],
+        "operationId": "remover",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/usuarios/buscar": {
+      "get": {
+        "tags": [
+          "usuario-controller"
+        ],
+        "operationId": "buscarPorEmail",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Usuario"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/solicitantes/{id}": {
+      "get": {
+        "tags": [
+          "solicitante-controller"
+        ],
+        "operationId": "buscarPorId_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Solicitante"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/solicitantes/buscar": {
+      "get": {
+        "tags": [
+          "solicitante-controller"
+        ],
+        "operationId": "buscarPorEmail_1",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Solicitante"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reservas/{id}": {
+      "get": {
+        "tags": [
+          "reserva-controller"
+        ],
+        "operationId": "buscarPorId_2",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reserva"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reservas/por-solicitante": {
+      "get": {
+        "tags": [
+          "reserva-controller"
+        ],
+        "operationId": "listarPorSolicitante",
+        "parameters": [
+          {
+            "name": "solicitanteId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Reserva"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reservas/ativas": {
+      "get": {
+        "tags": [
+          "reserva-controller"
+        ],
+        "operationId": "listarAtivas",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Reserva"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predios/{id}": {
+      "get": {
+        "tags": [
+          "predio-controller"
+        ],
+        "operationId": "buscarPorId_3",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Predio"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predios/buscar": {
+      "get": {
+        "tags": [
+          "predio-controller"
+        ],
+        "operationId": "buscarPorCodigo",
+        "parameters": [
+          {
+            "name": "codigo",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Predio"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notificacoes/{id}": {
+      "get": {
+        "tags": [
+          "notificacao-controller"
+        ],
+        "operationId": "buscarPorId_4",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Notificacao"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notificacoes/por-destinatario": {
+      "get": {
+        "tags": [
+          "notificacao-controller"
+        ],
+        "operationId": "listarPorDestinatario",
+        "parameters": [
+          {
+            "name": "destinatarioId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Notificacao"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notificacoes/nao-lidas": {
+      "get": {
+        "tags": [
+          "notificacao-controller"
+        ],
+        "operationId": "listarNaoLidas",
+        "parameters": [
+          {
+            "name": "destinatarioId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Notificacao"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "health-controller"
+        ],
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/espacos/{id}": {
+      "get": {
+        "tags": [
+          "espaco-controller"
+        ],
+        "operationId": "buscarPorId_5",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Espaco"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/espacos/por-predio": {
+      "get": {
+        "tags": [
+          "espaco-controller"
+        ],
+        "operationId": "listarPorPredio",
+        "parameters": [
+          {
+            "name": "predioId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Espaco"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/espacos/disponiveis": {
+      "get": {
+        "tags": [
+          "espaco-controller"
+        ],
+        "operationId": "listarDisponiveis",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Espaco"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateSolicitanteRequest": {
+        "type": "object",
+        "properties": {
+          "nome": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "Solicitante": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateReservaRequest": {
+        "type": "object",
+        "properties": {
+          "solicitanteId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "espacoId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "inicio": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fim": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "motivo": {
+            "type": "string"
+          }
+        }
+      },
+      "Espaco": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "capacidade": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "indisponivel": {
+            "type": "boolean"
+          },
+          "motivoIndisponibilidade": {
+            "type": "string"
+          },
+          "predio": {
+            "$ref": "#/components/schemas/Predio"
+          }
+        }
+      },
+      "Horarios": {
+        "type": "object",
+        "properties": {
+          "inicio": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fim": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Predio": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "localizacao": {
+            "type": "string"
+          }
+        }
+      },
+      "Reserva": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "solicitante": {
+            "$ref": "#/components/schemas/Solicitante"
+          },
+          "espaco": {
+            "$ref": "#/components/schemas/Espaco"
+          },
+          "horarios": {
+            "$ref": "#/components/schemas/Horarios"
+          },
+          "motivo": {
+            "type": "string"
+          },
+          "cancelada": {
+            "type": "boolean"
+          },
+          "criadaEm": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Notificacao": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "destinatario": {
+            "$ref": "#/components/schemas/Usuario"
+          },
+          "reserva": {
+            "$ref": "#/components/schemas/Reserva"
+          },
+          "mensagem": {
+            "type": "string"
+          },
+          "lida": {
+            "type": "boolean"
+          },
+          "enviadaEm": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Usuario": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateEspacoRequest": {
+        "type": "object",
+        "properties": {
+          "nome": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": "string"
+          },
+          "capacidade": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "predioId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/classroomscheduler/config/DemoDataConfig.java
+++ b/src/main/java/com/classroomscheduler/config/DemoDataConfig.java
@@ -1,0 +1,243 @@
+package com.classroomscheduler.config;
+
+import com.classroomscheduler.model.Auditorio;
+import com.classroomscheduler.model.Espaco;
+import com.classroomscheduler.model.Horarios;
+import com.classroomscheduler.model.Laboratorio;
+import com.classroomscheduler.model.Notificacao;
+import com.classroomscheduler.model.Predio;
+import com.classroomscheduler.model.Quadra;
+import com.classroomscheduler.model.Reserva;
+import com.classroomscheduler.model.Sala;
+import com.classroomscheduler.model.Solicitante;
+import com.classroomscheduler.repository.EspacoRepository;
+import com.classroomscheduler.repository.NotificacaoRepository;
+import com.classroomscheduler.repository.PredioRepository;
+import com.classroomscheduler.repository.ReservaRepository;
+import com.classroomscheduler.repository.SolicitanteRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDateTime;
+
+@Configuration
+public class DemoDataConfig {
+
+    @Bean
+    public CommandLineRunner demoDataRunner(
+            PredioRepository predioRepository,
+            EspacoRepository espacoRepository,
+            SolicitanteRepository solicitanteRepository,
+            ReservaRepository reservaRepository,
+            NotificacaoRepository notificacaoRepository,
+            @Value("${APP_DEMO_DATA_ENABLED:true}") boolean demoDataEnabled
+    ) {
+        return args -> {
+            if (!demoDataEnabled) {
+                return;
+            }
+
+            Predio predioA = buscarOuCriarPredio(
+                    predioRepository,
+                    "BL-A",
+                    "Predio Academico A",
+                    "Rua do Campus, 100"
+            );
+
+            Predio predioB = buscarOuCriarPredio(
+                    predioRepository,
+                    "BL-B",
+                    "Predio Academico B",
+                    "Rua do Campus, 200"
+            );
+
+            Espaco sala101 = buscarOuCriarEspaco(
+                    espacoRepository,
+                    predioA,
+                    "Sala 101",
+                    40,
+                    new Sala(),
+                    false,
+                    null
+            );
+
+            buscarOuCriarEspaco(
+                    espacoRepository,
+                    predioA,
+                    "Laboratorio Makers",
+                    25,
+                    new Laboratorio(),
+                    false,
+                    null
+            );
+
+            buscarOuCriarEspaco(
+                    espacoRepository,
+                    predioB,
+                    "Auditorio Principal",
+                    120,
+                    new Auditorio(),
+                    false,
+                    null
+            );
+
+            buscarOuCriarEspaco(
+                    espacoRepository,
+                    predioB,
+                    "Quadra Coberta",
+                    60,
+                    new Quadra(),
+                    true,
+                    "Indisponivel para manutencao preventiva"
+            );
+
+            Solicitante ana = buscarOuCriarSolicitante(
+                    solicitanteRepository,
+                    "Ana Souza",
+                    "ana.souza@classroom.local"
+            );
+
+            Solicitante bruno = buscarOuCriarSolicitante(
+                    solicitanteRepository,
+                    "Bruno Lima",
+                    "bruno.lima@classroom.local"
+            );
+
+            Reserva reservaDemo = buscarOuCriarReserva(
+                    reservaRepository,
+                    ana,
+                    sala101,
+                    "Apresentacao de projeto integrador"
+            );
+
+            buscarOuCriarNotificacao(
+                    notificacaoRepository,
+                    ana,
+                    reservaDemo,
+                    "Sua reserva de demonstracao foi criada com sucesso."
+            );
+
+            buscarOuCriarNotificacao(
+                    notificacaoRepository,
+                    bruno,
+                    null,
+                    "Voce ja pode explorar a API usando os dados de demonstracao."
+            );
+        };
+    }
+
+    private Predio buscarOuCriarPredio(
+            PredioRepository predioRepository,
+            String codigo,
+            String nome,
+            String localizacao
+    ) {
+        return predioRepository.findByCodigo(codigo)
+                .orElseGet(() -> {
+                    Predio predio = new Predio();
+                    predio.setCodigo(codigo);
+                    predio.setNome(nome);
+                    predio.setLocalizacao(localizacao);
+                    return predioRepository.save(predio);
+                });
+    }
+
+    private Solicitante buscarOuCriarSolicitante(
+            SolicitanteRepository solicitanteRepository,
+            String nome,
+            String email
+    ) {
+        return solicitanteRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    Solicitante solicitante = new Solicitante();
+                    solicitante.setNome(nome);
+                    solicitante.setEmail(email);
+                    return solicitanteRepository.save(solicitante);
+                });
+    }
+
+    private Espaco buscarOuCriarEspaco(
+            EspacoRepository espacoRepository,
+            Predio predio,
+            String nome,
+            Integer capacidade,
+            Espaco novoEspaco,
+            boolean indisponivel,
+            String motivoIndisponibilidade
+    ) {
+        return espacoRepository.findByPredioIdAndNomeIgnoreCase(predio.getId(), nome)
+                .orElseGet(() -> {
+                    novoEspaco.setNome(nome);
+                    novoEspaco.setCapacidade(capacidade);
+                    novoEspaco.setPredio(predio);
+                    novoEspaco.setIndisponivel(indisponivel);
+                    novoEspaco.setMotivoIndisponibilidade(motivoIndisponibilidade);
+                    return espacoRepository.save(novoEspaco);
+                });
+    }
+
+    private Reserva buscarOuCriarReserva(
+            ReservaRepository reservaRepository,
+            Solicitante solicitante,
+            Espaco espaco,
+            String motivo
+    ) {
+        boolean existeReserva = reservaRepository.existsBySolicitanteIdAndEspacoIdAndMotivo(
+                solicitante.getId(),
+                espaco.getId(),
+                motivo
+        );
+
+        if (existeReserva) {
+            return reservaRepository.findFirstBySolicitanteIdAndEspacoIdAndMotivo(
+                    solicitante.getId(),
+                    espaco.getId(),
+                    motivo
+            ).orElseThrow();
+        }
+
+        Horarios horarios = new Horarios();
+        LocalDateTime inicio = LocalDateTime.now()
+                .plusDays(1)
+                .withHour(10)
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0);
+
+        horarios.setInicio(inicio);
+        horarios.setFim(inicio.plusHours(2));
+
+        Reserva reserva = new Reserva();
+        reserva.setSolicitante(solicitante);
+        reserva.setEspaco(espaco);
+        reserva.setHorarios(horarios);
+        reserva.setMotivo(motivo);
+        reserva.setCancelada(false);
+        return reservaRepository.save(reserva);
+    }
+
+    private void buscarOuCriarNotificacao(
+            NotificacaoRepository notificacaoRepository,
+            Solicitante destinatario,
+            Reserva reserva,
+            String mensagem
+    ) {
+        boolean existeNotificacao = notificacaoRepository.existsByDestinatarioIdAndMensagem(
+                destinatario.getId(),
+                mensagem
+        );
+
+        if (existeNotificacao) {
+            return;
+        }
+
+        Notificacao notificacao = new Notificacao();
+        notificacao.setDestinatario(destinatario);
+        notificacao.setReserva(reserva);
+        notificacao.setMensagem(mensagem);
+        notificacao.setLida(false);
+        notificacaoRepository.save(notificacao);
+    }
+}

--- a/src/main/java/com/classroomscheduler/repository/EspacoRepository.java
+++ b/src/main/java/com/classroomscheduler/repository/EspacoRepository.java
@@ -4,6 +4,7 @@ import com.classroomscheduler.model.Espaco;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EspacoRepository extends JpaRepository<Espaco, Long> {
 
@@ -12,4 +13,6 @@ public interface EspacoRepository extends JpaRepository<Espaco, Long> {
     List<Espaco> findByPredioId(Long predioId);
 
     List<Espaco> findByCapacidadeGreaterThanEqual(Integer capacidade);
+
+    Optional<Espaco> findByPredioIdAndNomeIgnoreCase(Long predioId, String nome);
 }

--- a/src/main/java/com/classroomscheduler/repository/NotificacaoRepository.java
+++ b/src/main/java/com/classroomscheduler/repository/NotificacaoRepository.java
@@ -10,4 +10,6 @@ public interface NotificacaoRepository extends JpaRepository<Notificacao, Long> 
     List<Notificacao> findByDestinatarioId(Long destinatarioId);
 
     List<Notificacao> findByDestinatarioIdAndLidaFalse(Long destinatarioId);
+
+    boolean existsByDestinatarioIdAndMensagem(Long destinatarioId, String mensagem);
 }

--- a/src/main/java/com/classroomscheduler/repository/ReservaRepository.java
+++ b/src/main/java/com/classroomscheduler/repository/ReservaRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservaRepository extends JpaRepository<Reserva, Long> {
 
@@ -18,5 +19,17 @@ public interface ReservaRepository extends JpaRepository<Reserva, Long> {
             Long espacoId,
             LocalDateTime fim,
             LocalDateTime inicio
+    );
+
+    boolean existsBySolicitanteIdAndEspacoIdAndMotivo(
+            Long solicitanteId,
+            Long espacoId,
+            String motivo
+    );
+
+    Optional<Reserva> findFirstBySolicitanteIdAndEspacoIdAndMotivo(
+            Long solicitanteId,
+            Long espacoId,
+            String motivo
     );
 }


### PR DESCRIPTION
## What changed
- added a local demo data seed for manual API exploration
- exported the current OpenAPI contract to docs/openapi.json
- aligned the Postman collection with the generated API contract and demo data
- updated endpoint documentation and README references

## Why it changed
- the project needed a simple local dataset to demonstrate the API without manual setup
- the repository also needed a committed API contract and synced docs for integration and testing

## Impact
- the application now starts with demo buildings, spaces, requesters, a sample reservation, and notifications by default
- API consumers can rely on the committed OpenAPI file and Postman collection for local testing
- the docs now reflect the endpoints actually exposed by the current backend

## Validation
- ./mvnw -q -DskipTests compile with JDK 25
- validated docs/openapi.json and docs/api-collection.postman_collection.json with PowerShell ConvertFrom-Json
- smoke-checked Spring Boot startup logs after the integration changes