### PR TITLE
Add JWT authentication backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,28 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.13.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.13.0</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.13.0</version>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springdoc</groupId>

--- a/src/main/java/com/classroomscheduler/config/AdminBootstrapConfig.java
+++ b/src/main/java/com/classroomscheduler/config/AdminBootstrapConfig.java
@@ -1,11 +1,13 @@
 package com.classroomscheduler.config;
 
 import com.classroomscheduler.model.Admin;
+import com.classroomscheduler.model.PapelUsuario;
 import com.classroomscheduler.repository.AdminRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class AdminBootstrapConfig {
@@ -13,8 +15,10 @@ public class AdminBootstrapConfig {
     @Bean
     public CommandLineRunner adminBootstrapRunner(
             AdminRepository adminRepository,
+            PasswordEncoder passwordEncoder,
             @Value("${APP_ADMIN_NOME:Administrador Padrao}") String adminNome,
-            @Value("${APP_ADMIN_EMAIL:admin@classroom.local}") String adminEmail
+            @Value("${APP_ADMIN_EMAIL:admin@insper.edu.br}") String adminEmail,
+            @Value("${APP_ADMIN_PASSWORD:admin1234}") String adminPassword
     ) {
         return args -> {
             if (adminRepository.findByEmail(adminEmail).isPresent()) {
@@ -23,7 +27,9 @@ public class AdminBootstrapConfig {
 
             Admin admin = new Admin();
             admin.setNome(adminNome);
-            admin.setEmail(adminEmail);
+            admin.setEmail(adminEmail.trim().toLowerCase());
+            admin.setPapel(PapelUsuario.ADMIN);
+            admin.setSenhaHash(passwordEncoder.encode(adminPassword));
             adminRepository.save(admin);
         };
     }

--- a/src/main/java/com/classroomscheduler/config/DemoDataConfig.java
+++ b/src/main/java/com/classroomscheduler/config/DemoDataConfig.java
@@ -5,11 +5,13 @@ import com.classroomscheduler.model.Espaco;
 import com.classroomscheduler.model.Horarios;
 import com.classroomscheduler.model.Laboratorio;
 import com.classroomscheduler.model.Notificacao;
+import com.classroomscheduler.model.PapelUsuario;
 import com.classroomscheduler.model.Predio;
 import com.classroomscheduler.model.Quadra;
 import com.classroomscheduler.model.Reserva;
 import com.classroomscheduler.model.Sala;
 import com.classroomscheduler.model.Solicitante;
+import com.classroomscheduler.model.TipoSolicitante;
 import com.classroomscheduler.repository.EspacoRepository;
 import com.classroomscheduler.repository.NotificacaoRepository;
 import com.classroomscheduler.repository.PredioRepository;
@@ -95,14 +97,12 @@ public class DemoDataConfig {
 
             Solicitante ana = buscarOuCriarSolicitante(
                     solicitanteRepository,
-                    "Ana Souza",
-                    "ana.souza@classroom.local"
+                    "ana.souza@al.insper.edu.br"
             );
 
             Solicitante bruno = buscarOuCriarSolicitante(
                     solicitanteRepository,
-                    "Bruno Lima",
-                    "bruno.lima@classroom.local"
+                    "bruno.lima@insper.edu.br"
             );
 
             Reserva reservaDemo = buscarOuCriarReserva(
@@ -146,14 +146,19 @@ public class DemoDataConfig {
 
     private Solicitante buscarOuCriarSolicitante(
             SolicitanteRepository solicitanteRepository,
-            String nome,
             String email
     ) {
         return solicitanteRepository.findByEmail(email)
                 .orElseGet(() -> {
                     Solicitante solicitante = new Solicitante();
-                    solicitante.setNome(nome);
+                    solicitante.setNome(email);
                     solicitante.setEmail(email);
+                    solicitante.setPapel(PapelUsuario.SOLICITANTE);
+                    solicitante.setTipoSolicitante(
+                            email.endsWith("@al.insper.edu.br")
+                                    ? TipoSolicitante.ALUNO
+                                    : TipoSolicitante.FUNCIONARIO
+                    );
                     return solicitanteRepository.save(solicitante);
                 });
     }

--- a/src/main/java/com/classroomscheduler/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/classroomscheduler/config/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.classroomscheduler.config;
+
+import com.classroomscheduler.model.Usuario;
+import com.classroomscheduler.repository.UsuarioRepository;
+import com.classroomscheduler.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UsuarioRepository usuarioRepository;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UsuarioRepository usuarioRepository) {
+        this.jwtService = jwtService;
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        try {
+            String email = jwtService.extrairEmail(token);
+
+            if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                Usuario usuario = usuarioRepository.findByEmail(email).orElse(null);
+
+                if (usuario != null && jwtService.tokenValido(token, usuario)) {
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            usuario.getEmail(),
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + usuario.getPapel().name()))
+                    );
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        } catch (RuntimeException ignored) {
+            SecurityContextHolder.clearContext();
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/classroomscheduler/config/SecurityConfig.java
+++ b/src/main/java/com/classroomscheduler/config/SecurityConfig.java
@@ -1,0 +1,58 @@
+package com.classroomscheduler.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/health",
+                                "/h2-console/**",
+                                "/docs/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .requestMatchers("/usuarios/**").hasRole("ADMIN")
+                        .requestMatchers("/solicitantes/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/reservas").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/reservas/ativas").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/notificacoes").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/notificacoes").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/espacos").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/espacos/*/indisponibilidade").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/predios").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/classroomscheduler/controller/AuthController.java
+++ b/src/main/java/com/classroomscheduler/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.classroomscheduler.controller;
+
+import com.classroomscheduler.dto.AuthRequest;
+import com.classroomscheduler.dto.AuthResponse;
+import com.classroomscheduler.dto.UsuarioAuthResponse;
+import com.classroomscheduler.model.Usuario;
+import com.classroomscheduler.repository.UsuarioRepository;
+import com.classroomscheduler.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final UsuarioRepository usuarioRepository;
+
+    public AuthController(AuthService authService, UsuarioRepository usuarioRepository) {
+        this.authService = authService;
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@RequestBody AuthRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(authService.registrar(request));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody AuthRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UsuarioAuthResponse> me(Authentication authentication) {
+        Usuario usuario = usuarioRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        return ResponseEntity.ok(new UsuarioAuthResponse(usuario));
+    }
+}

--- a/src/main/java/com/classroomscheduler/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/classroomscheduler/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.classroomscheduler.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,6 +21,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException exception) {
         return ResponseEntity.badRequest()
+                .body(Map.of("erro", exception.getMessage()));
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Map<String, String>> handleBadCredentials(BadCredentialsException exception) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(Map.of("erro", exception.getMessage()));
     }
 }

--- a/src/main/java/com/classroomscheduler/controller/NotificacaoController.java
+++ b/src/main/java/com/classroomscheduler/controller/NotificacaoController.java
@@ -1,9 +1,13 @@
 package com.classroomscheduler.controller;
 
+import com.classroomscheduler.model.PapelUsuario;
 import com.classroomscheduler.model.Notificacao;
+import com.classroomscheduler.model.Usuario;
+import com.classroomscheduler.repository.UsuarioRepository;
 import com.classroomscheduler.service.NotificacaoService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -20,9 +25,11 @@ import java.util.List;
 public class NotificacaoController {
 
     private final NotificacaoService notificacaoService;
+    private final UsuarioRepository usuarioRepository;
 
-    public NotificacaoController(NotificacaoService notificacaoService) {
+    public NotificacaoController(NotificacaoService notificacaoService, UsuarioRepository usuarioRepository) {
         this.notificacaoService = notificacaoService;
+        this.usuarioRepository = usuarioRepository;
     }
 
     @GetMapping
@@ -36,12 +43,14 @@ public class NotificacaoController {
     }
 
     @GetMapping("/por-destinatario")
-    public ResponseEntity<List<Notificacao>> listarPorDestinatario(@RequestParam Long destinatarioId) {
+    public ResponseEntity<List<Notificacao>> listarPorDestinatario(@RequestParam Long destinatarioId, Authentication authentication) {
+        validarAcessoDestinatario(destinatarioId, authentication);
         return ResponseEntity.ok(notificacaoService.listarPorDestinatario(destinatarioId));
     }
 
     @GetMapping("/nao-lidas")
-    public ResponseEntity<List<Notificacao>> listarNaoLidas(@RequestParam Long destinatarioId) {
+    public ResponseEntity<List<Notificacao>> listarNaoLidas(@RequestParam Long destinatarioId, Authentication authentication) {
+        validarAcessoDestinatario(destinatarioId, authentication);
         return ResponseEntity.ok(notificacaoService.listarNaoLidas(destinatarioId));
     }
 
@@ -51,7 +60,17 @@ public class NotificacaoController {
     }
 
     @PatchMapping("/{id}/lida")
-    public ResponseEntity<Notificacao> marcarComoLida(@PathVariable Long id) {
+    public ResponseEntity<Notificacao> marcarComoLida(@PathVariable Long id, Authentication authentication) {
+        Notificacao notificacao = notificacaoService.buscarPorId(id);
+        validarAcessoDestinatario(notificacao.getDestinatario().getId(), authentication);
         return ResponseEntity.ok(notificacaoService.marcarComoLida(id));
+    }
+
+    private void validarAcessoDestinatario(Long destinatarioId, Authentication authentication) {
+        Usuario usuario = usuarioRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        if (usuario.getPapel() == PapelUsuario.SOLICITANTE && !usuario.getId().equals(destinatarioId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/classroomscheduler/controller/ReservaController.java
+++ b/src/main/java/com/classroomscheduler/controller/ReservaController.java
@@ -1,10 +1,14 @@
 package com.classroomscheduler.controller;
 
 import com.classroomscheduler.dto.CreateReservaRequest;
+import com.classroomscheduler.model.PapelUsuario;
 import com.classroomscheduler.model.Reserva;
+import com.classroomscheduler.model.Usuario;
+import com.classroomscheduler.repository.UsuarioRepository;
 import com.classroomscheduler.service.ReservaService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -21,9 +26,11 @@ import java.util.List;
 public class ReservaController {
 
     private final ReservaService reservaService;
+    private final UsuarioRepository usuarioRepository;
 
-    public ReservaController(ReservaService reservaService) {
+    public ReservaController(ReservaService reservaService, UsuarioRepository usuarioRepository) {
         this.reservaService = reservaService;
+        this.usuarioRepository = usuarioRepository;
     }
 
     @GetMapping
@@ -42,17 +49,35 @@ public class ReservaController {
     }
 
     @GetMapping("/por-solicitante")
-    public ResponseEntity<List<Reserva>> listarPorSolicitante(@RequestParam Long solicitanteId) {
+    public ResponseEntity<List<Reserva>> listarPorSolicitante(@RequestParam Long solicitanteId, Authentication authentication) {
+        Usuario usuario = usuarioAutenticado(authentication);
+        if (usuario.getPapel() == PapelUsuario.SOLICITANTE && !usuario.getId().equals(solicitanteId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
         return ResponseEntity.ok(reservaService.listarPorSolicitante(solicitanteId));
     }
 
     @PostMapping
-    public ResponseEntity<Reserva> criar(@RequestBody CreateReservaRequest request) {
+    public ResponseEntity<Reserva> criar(@RequestBody CreateReservaRequest request, Authentication authentication) {
+        Usuario usuario = usuarioAutenticado(authentication);
+        if (usuario.getPapel() == PapelUsuario.SOLICITANTE) {
+            request.setSolicitanteId(usuario.getId());
+        }
         return ResponseEntity.status(HttpStatus.CREATED).body(reservaService.criar(request));
     }
 
     @PatchMapping("/{id}/cancelar")
-    public ResponseEntity<Reserva> cancelar(@PathVariable Long id) {
+    public ResponseEntity<Reserva> cancelar(@PathVariable Long id, Authentication authentication) {
+        Usuario usuario = usuarioAutenticado(authentication);
+        Reserva reserva = reservaService.buscarPorId(id);
+        if (usuario.getPapel() == PapelUsuario.SOLICITANTE && !usuario.getId().equals(reserva.getSolicitante().getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
         return ResponseEntity.ok(reservaService.cancelar(id));
+    }
+
+    private Usuario usuarioAutenticado(Authentication authentication) {
+        return usuarioRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
     }
 }

--- a/src/main/java/com/classroomscheduler/dto/AuthRequest.java
+++ b/src/main/java/com/classroomscheduler/dto/AuthRequest.java
@@ -1,0 +1,27 @@
+package com.classroomscheduler.dto;
+
+public class AuthRequest {
+
+    private String email;
+
+    private String senha;
+
+    public AuthRequest() {
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getSenha() {
+        return senha;
+    }
+
+    public void setSenha(String senha) {
+        this.senha = senha;
+    }
+}

--- a/src/main/java/com/classroomscheduler/dto/AuthResponse.java
+++ b/src/main/java/com/classroomscheduler/dto/AuthResponse.java
@@ -1,0 +1,26 @@
+package com.classroomscheduler.dto;
+
+import com.classroomscheduler.model.Usuario;
+
+public class AuthResponse {
+
+    private String token;
+
+    private UsuarioAuthResponse usuario;
+
+    public AuthResponse() {
+    }
+
+    public AuthResponse(String token, Usuario usuario) {
+        this.token = token;
+        this.usuario = new UsuarioAuthResponse(usuario);
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public UsuarioAuthResponse getUsuario() {
+        return usuario;
+    }
+}

--- a/src/main/java/com/classroomscheduler/dto/UsuarioAuthResponse.java
+++ b/src/main/java/com/classroomscheduler/dto/UsuarioAuthResponse.java
@@ -1,0 +1,42 @@
+package com.classroomscheduler.dto;
+
+import com.classroomscheduler.model.PapelUsuario;
+import com.classroomscheduler.model.TipoSolicitante;
+import com.classroomscheduler.model.Usuario;
+
+public class UsuarioAuthResponse {
+
+    private Long id;
+
+    private String email;
+
+    private PapelUsuario papel;
+
+    private TipoSolicitante tipoSolicitante;
+
+    public UsuarioAuthResponse() {
+    }
+
+    public UsuarioAuthResponse(Usuario usuario) {
+        this.id = usuario.getId();
+        this.email = usuario.getEmail();
+        this.papel = usuario.getPapel();
+        this.tipoSolicitante = usuario.getTipoSolicitante();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public PapelUsuario getPapel() {
+        return papel;
+    }
+
+    public TipoSolicitante getTipoSolicitante() {
+        return tipoSolicitante;
+    }
+}

--- a/src/main/java/com/classroomscheduler/model/PapelUsuario.java
+++ b/src/main/java/com/classroomscheduler/model/PapelUsuario.java
@@ -1,0 +1,6 @@
+package com.classroomscheduler.model;
+
+public enum PapelUsuario {
+    ADMIN,
+    SOLICITANTE
+}

--- a/src/main/java/com/classroomscheduler/model/TipoSolicitante.java
+++ b/src/main/java/com/classroomscheduler/model/TipoSolicitante.java
@@ -1,0 +1,6 @@
+package com.classroomscheduler.model;
+
+public enum TipoSolicitante {
+    ALUNO,
+    FUNCIONARIO
+}

--- a/src/main/java/com/classroomscheduler/model/Usuario.java
+++ b/src/main/java/com/classroomscheduler/model/Usuario.java
@@ -1,6 +1,10 @@
 package com.classroomscheduler.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,7 +21,17 @@ public abstract class Usuario {
 
     private String nome;
 
+    @Column(unique = true, nullable = false)
     private String email;
+
+    @JsonIgnore
+    private String senhaHash;
+
+    @Enumerated(EnumType.STRING)
+    private PapelUsuario papel;
+
+    @Enumerated(EnumType.STRING)
+    private TipoSolicitante tipoSolicitante;
 
     public Usuario() {
     }
@@ -44,5 +58,29 @@ public abstract class Usuario {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getSenhaHash() {
+        return senhaHash;
+    }
+
+    public void setSenhaHash(String senhaHash) {
+        this.senhaHash = senhaHash;
+    }
+
+    public PapelUsuario getPapel() {
+        return papel;
+    }
+
+    public void setPapel(PapelUsuario papel) {
+        this.papel = papel;
+    }
+
+    public TipoSolicitante getTipoSolicitante() {
+        return tipoSolicitante;
+    }
+
+    public void setTipoSolicitante(TipoSolicitante tipoSolicitante) {
+        this.tipoSolicitante = tipoSolicitante;
     }
 }

--- a/src/main/java/com/classroomscheduler/service/AuthService.java
+++ b/src/main/java/com/classroomscheduler/service/AuthService.java
@@ -1,0 +1,93 @@
+package com.classroomscheduler.service;
+
+import com.classroomscheduler.dto.AuthRequest;
+import com.classroomscheduler.dto.AuthResponse;
+import com.classroomscheduler.model.PapelUsuario;
+import com.classroomscheduler.model.Solicitante;
+import com.classroomscheduler.model.TipoSolicitante;
+import com.classroomscheduler.model.Usuario;
+import com.classroomscheduler.repository.SolicitanteRepository;
+import com.classroomscheduler.repository.UsuarioRepository;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@Service
+public class AuthService {
+
+    private final UsuarioRepository usuarioRepository;
+    private final SolicitanteRepository solicitanteRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    public AuthService(
+            UsuarioRepository usuarioRepository,
+            SolicitanteRepository solicitanteRepository,
+            PasswordEncoder passwordEncoder,
+            JwtService jwtService
+    ) {
+        this.usuarioRepository = usuarioRepository;
+        this.solicitanteRepository = solicitanteRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+    }
+
+    public AuthResponse registrar(AuthRequest request) {
+        String email = normalizarEmail(request.getEmail());
+        validarSenha(request.getSenha());
+
+        if (usuarioRepository.findByEmail(email).isPresent()) {
+            throw new IllegalArgumentException("Ja existe usuario com esse email.");
+        }
+
+        Solicitante solicitante = new Solicitante();
+        solicitante.setEmail(email);
+        solicitante.setNome(email);
+        solicitante.setPapel(PapelUsuario.SOLICITANTE);
+        solicitante.setTipoSolicitante(inferirTipoSolicitante(email));
+        solicitante.setSenhaHash(passwordEncoder.encode(request.getSenha()));
+
+        Usuario salvo = solicitanteRepository.save(solicitante);
+        return new AuthResponse(jwtService.gerarToken(salvo), salvo);
+    }
+
+    public AuthResponse login(AuthRequest request) {
+        String email = normalizarEmail(request.getEmail());
+        Usuario usuario = usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new BadCredentialsException("Email ou senha invalidos."));
+
+        if (usuario.getSenhaHash() == null || !passwordEncoder.matches(request.getSenha(), usuario.getSenhaHash())) {
+            throw new BadCredentialsException("Email ou senha invalidos.");
+        }
+
+        return new AuthResponse(jwtService.gerarToken(usuario), usuario);
+    }
+
+    public String normalizarEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Email e obrigatorio.");
+        }
+
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private void validarSenha(String senha) {
+        if (senha == null || senha.length() < 6) {
+            throw new IllegalArgumentException("Senha deve possuir pelo menos 6 caracteres.");
+        }
+    }
+
+    private TipoSolicitante inferirTipoSolicitante(String email) {
+        if (email.endsWith("@al.insper.edu.br")) {
+            return TipoSolicitante.ALUNO;
+        }
+
+        if (email.endsWith("@insper.edu.br")) {
+            return TipoSolicitante.FUNCIONARIO;
+        }
+
+        throw new IllegalArgumentException("Email deve ser institucional do Insper.");
+    }
+}

--- a/src/main/java/com/classroomscheduler/service/JwtService.java
+++ b/src/main/java/com/classroomscheduler/service/JwtService.java
@@ -1,0 +1,59 @@
+package com.classroomscheduler.service;
+
+import com.classroomscheduler.model.Usuario;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    private final SecretKey secretKey;
+    private final long expirationMillis;
+
+    public JwtService(
+            @Value("${APP_JWT_SECRET:dev-secret-key-change-me-dev-secret-key-change-me}") String secret,
+            @Value("${APP_JWT_EXPIRATION_MILLIS:7200000}") long expirationMillis
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMillis = expirationMillis;
+    }
+
+    public String gerarToken(Usuario usuario) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(usuario.getEmail())
+                .claim("usuarioId", usuario.getId())
+                .claim("papel", usuario.getPapel().name())
+                .claim("tipoSolicitante", usuario.getTipoSolicitante() == null ? null : usuario.getTipoSolicitante().name())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusMillis(expirationMillis)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String extrairEmail(String token) {
+        return extrairClaims(token).getSubject();
+    }
+
+    public boolean tokenValido(String token, Usuario usuario) {
+        Claims claims = extrairClaims(token);
+        return usuario.getEmail().equals(claims.getSubject())
+                && claims.getExpiration().after(new Date());
+    }
+
+    private Claims extrairClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/classroomscheduler/service/SolicitanteService.java
+++ b/src/main/java/com/classroomscheduler/service/SolicitanteService.java
@@ -1,11 +1,14 @@
 package com.classroomscheduler.service;
 
 import com.classroomscheduler.dto.CreateSolicitanteRequest;
+import com.classroomscheduler.model.PapelUsuario;
 import com.classroomscheduler.model.Solicitante;
+import com.classroomscheduler.model.TipoSolicitante;
 import com.classroomscheduler.repository.SolicitanteRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 
 @Service
@@ -40,13 +43,29 @@ public class SolicitanteService {
             throw new IllegalArgumentException("Solicitante deve possuir email.");
         }
 
-        if (solicitanteRepository.findByEmail(request.getEmail()).isPresent()) {
+        String email = request.getEmail().trim().toLowerCase(Locale.ROOT);
+
+        if (solicitanteRepository.findByEmail(email).isPresent()) {
             throw new IllegalArgumentException("Ja existe solicitante com esse email.");
         }
 
         Solicitante solicitante = new Solicitante();
         solicitante.setNome(request.getNome());
-        solicitante.setEmail(request.getEmail());
+        solicitante.setEmail(email);
+        solicitante.setPapel(PapelUsuario.SOLICITANTE);
+        solicitante.setTipoSolicitante(inferirTipoSolicitante(email));
         return solicitanteRepository.save(solicitante);
+    }
+
+    private TipoSolicitante inferirTipoSolicitante(String email) {
+        if (email.endsWith("@al.insper.edu.br")) {
+            return TipoSolicitante.ALUNO;
+        }
+
+        if (email.endsWith("@insper.edu.br")) {
+            return TipoSolicitante.FUNCIONARIO;
+        }
+
+        throw new IllegalArgumentException("Email deve ser institucional do Insper.");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.jpa.show-sql=true
 
 springdoc.swagger-ui.path=/docs/swagger-ui.html
 springdoc.api-docs.path=/docs/api-docs
+
+APP_JWT_SECRET=dev-secret-key-change-me-dev-secret-key-change-me
+APP_JWT_EXPIRATION_MILLIS=7200000


### PR DESCRIPTION
## Summary
- Add Spring Security and JWT authentication endpoints for register, login, and current user lookup.
- Persist user roles, requester type, and BCrypt password hashes while keeping password hashes out of API responses.
- Protect administrative endpoints with ADMIN and constrain requester-owned reservation/notification access.

## Validation
- ./mvnw.cmd test
- Smoke-tested register/login/me plus requester 403 and admin 200 authorization behavior on a temporary local port.